### PR TITLE
fix: allow mixed define order for fk and index in table decl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9
-	github.com/kwilteam/kuneiform-grammar-go v0.3.0
+	github.com/kwilteam/kuneiform-grammar-go v0.3.1
 	github.com/kwilteam/kwil-db v0.3.2-0.20230619192610-61f4f30d30e9
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kwilteam/kuneiform-grammar-go v0.3.0 h1:GSbkAc6416QGluMJfItw7+cc5uGf9NWuy5qn0eqORxg=
-github.com/kwilteam/kuneiform-grammar-go v0.3.0/go.mod h1:uki0OHLCXttIQqy/DsJ5X9WaNtRf3HB/OmxCCd+XdZU=
+github.com/kwilteam/kuneiform-grammar-go v0.3.1 h1:cR/GlEe6kWkH1ymchevlsG/83Gzew+poccQ+ELEmeEo=
+github.com/kwilteam/kuneiform-grammar-go v0.3.1/go.mod h1:uki0OHLCXttIQqy/DsJ5X9WaNtRf3HB/OmxCCd+XdZU=
 github.com/kwilteam/kwil-db v0.3.2-0.20230619192610-61f4f30d30e9 h1:dunxlt+Q/+cw7RbEuGNMgYHprWh8yViUb0RkKJtH364=
 github.com/kwilteam/kwil-db v0.3.2-0.20230619192610-61f4f30d30e9/go.mod h1:S2yy4JtJTcSkwZxZpPsUthK33QlMl3R5wJJXH5w6Iiw=
 github.com/kwilteam/sql-grammar-go v0.0.1 h1:Crr8YHyg1ZzrgLGuRNCa/U8rFPZ5EWt+qW/zR5d9czM=

--- a/kfparser/parser_test.go
+++ b/kfparser/parser_test.go
@@ -363,6 +363,48 @@ func TestParse_valid_syntax(t *testing.T) {
 						},
 					},
 				}...)},
+		// fk and index
+		{"table with mixed foreign key and index", `database td1;
+			table tt1 {
+				tc1 int, tc2 text,
+				#idx1 primary (tc1,tc2),
+				foreign_key (tc1) references tt1 (tc1) on_delete cascade on_update restrict,
+				#idx2 primary (tc1,tc2),
+		}`,
+			&schema.Schema{
+				Name:  "td1",
+				Owner: "",
+				Tables: []schema.Table{
+					{
+						Name: "tt1",
+						Columns: []schema.Column{
+							{Name: "tc1", Type: schema.ColInt},
+							{Name: "tc2", Type: schema.ColText},
+						},
+						Indexes: []schema.Index{
+							{Name: "idx1", Type: schema.IdxPrimary, Columns: []string{"tc1", "tc2"}},
+							{Name: "idx2", Type: schema.IdxPrimary, Columns: []string{"tc1", "tc2"}},
+						},
+						ForeignKeys: []schema.ForeignKey{
+							{
+								ChildKeys:   []string{"tc1"},
+								ParentTable: "tt1",
+								ParentKeys:  []string{"tc1"},
+								Actions: []schema.ForeignKeyAction{
+									{
+										On: schema.ON_DELETE,
+										Do: schema.DO_CASCADE,
+									},
+									{
+										On: schema.ON_UPDATE,
+										Do: schema.DO_RESTRICT,
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
 		// action
 		{"table with action insert", `database td1; table tt1 { tc1 int, tc2 text }
 			action act1() public { insert into tt1 (tc1, tc2) values (1, "2"); }`,

--- a/kfparser/visitor.go
+++ b/kfparser/visitor.go
@@ -108,12 +108,24 @@ func (v *KFVisitor) VisitTable_decl(ctx *kfgrammar.Table_declContext) interface{
 
 	t.Columns = v.Visit(ctx.Column_def_list()).([]schema.Column)
 
-	if ctx.Index_def_list() != nil {
-		t.Indexes = v.Visit(ctx.Index_def_list()).([]schema.Index)
+	indexCount := len(ctx.AllIndex_def())
+
+	if indexCount > 0 {
+		t.Indexes = make([]schema.Index, indexCount)
+		for i, indexDef := range ctx.AllIndex_def() {
+			index := v.Visit(indexDef).(*schema.Index)
+			t.Indexes[i] = *index
+		}
 	}
 
-	if ctx.Foreign_key_def_list() != nil {
-		t.ForeignKeys = v.Visit(ctx.Foreign_key_def_list()).([]schema.ForeignKey)
+	fkCount := len(ctx.AllForeign_key_def())
+	if fkCount > 0 {
+		t.ForeignKeys = make([]schema.ForeignKey, fkCount)
+
+		for i, fkDef := range ctx.AllForeign_key_def() {
+			fk := v.Visit(fkDef).(*schema.ForeignKey)
+			t.ForeignKeys[i] = *fk
+		}
 	}
 
 	return &t
@@ -187,19 +199,6 @@ func (c *KFVisitor) VisitColumn_constraint(ctx *kfgrammar.Column_constraintConte
 	return &attr
 }
 
-// VisitIndex_def_list is called when parsing index definition list, return []schema.Index
-func (v *KFVisitor) VisitIndex_def_list(ctx *kfgrammar.Index_def_listContext) interface{} {
-	indexCount := len(ctx.AllIndex_def())
-	indexes := make([]schema.Index, indexCount)
-
-	for i, indexDef := range ctx.AllIndex_def() {
-		index := v.Visit(indexDef).(*schema.Index)
-		indexes[i] = *index
-	}
-
-	return indexes
-}
-
 // VisitIndex_def is called when parsing index definition, return *schema.Index
 func (v *KFVisitor) VisitIndex_def(ctx *kfgrammar.Index_defContext) interface{} {
 	i := schema.Index{}
@@ -229,18 +228,6 @@ func (v *KFVisitor) VisitColumn_name_list(ctx *kfgrammar.Column_name_listContext
 	}
 
 	return columns
-}
-
-func (v *KFVisitor) VisitForeign_key_def_list(ctx *kfgrammar.Foreign_key_def_listContext) interface{} {
-	fkCount := len(ctx.AllForeign_key_def())
-	fks := make([]schema.ForeignKey, fkCount)
-
-	for i, fkDef := range ctx.AllForeign_key_def() {
-		fk := v.Visit(fkDef).(*schema.ForeignKey)
-		fks[i] = *fk
-	}
-
-	return fks
 }
 
 func (v *KFVisitor) VisitForeign_key_def(ctx *kfgrammar.Foreign_key_defContext) interface{} {


### PR DESCRIPTION
fk and index could be defined in any order