### PR TITLE
feat: support new action auxiliary `owner`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9
-	github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807191258-143bb3c13545
+	github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807195420-c5c1c840c665
 	github.com/kwilteam/kwil-db v0.4.1-0.20230721231103-a25e503b79a8
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.3

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kwilteam/action-grammar-go v0.0.0-20230626155541-72265621f427 h1:MYJuuqYXqJN7m4CwPrYPdsOCy48mtMTH4u8zXRySKtg=
 github.com/kwilteam/action-grammar-go v0.0.0-20230626155541-72265621f427/go.mod h1:2KYz1ittMk7BbKRJSnSnRSysrgDUUtNB1Ha47ZMdc6M=
-github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807191258-143bb3c13545 h1:5oumiJQJY1Mhc/H2E97wNjqYj4aUdZo4Y2AoOdwhH2M=
-github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807191258-143bb3c13545/go.mod h1:uki0OHLCXttIQqy/DsJ5X9WaNtRf3HB/OmxCCd+XdZU=
+github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807195420-c5c1c840c665 h1:Y4s8p3u5S6gicNoHtOqFM+GI+UNRiSkN2rWdyGvZ6nw=
+github.com/kwilteam/kuneiform-grammar-go v0.4.1-0.20230807195420-c5c1c840c665/go.mod h1:uki0OHLCXttIQqy/DsJ5X9WaNtRf3HB/OmxCCd+XdZU=
 github.com/kwilteam/kwil-db v0.4.1-0.20230721231103-a25e503b79a8 h1:M39ma+5BQ8eH5vQW7IlpGiaj26M4XUE1FhUsg25uors=
 github.com/kwilteam/kwil-db v0.4.1-0.20230721231103-a25e503b79a8/go.mod h1:UHBvRl97FIeqO2wqrU2rIDU/oiIvMBfEHRnUhsOejRQ=
 github.com/kwilteam/sql-grammar-go v0.0.2 h1:Tg8xo/Pzd72QsO19wwNvFrpw2muuBaERP7XTv21U4Iw=

--- a/kfparser/visitor.go
+++ b/kfparser/visitor.go
@@ -366,7 +366,12 @@ func (v *KFVisitor) VisitAction_attr_list(ctx *kfgrammar.Action_attr_listContext
 				panic(fmt.Errorf("%w: %s", schema.ErrActionAuxiliaryAlreadySet, aux.GetText()))
 			}
 			seenAuxs[aux.GetText()] = true
-			aa.auxs[i] = schema.AuxiliaryType(aux.GetText())
+			switch {
+			case aux.GetText() == schema.AuxiliaryTypeMustSign.String():
+				aa.auxs[i] = schema.AuxiliaryTypeMustSign
+			case aux.GetText() == schema.AuxiliaryTypeOwner.String():
+				aa.auxs[i] = schema.AuxiliaryTypeOwner
+			}
 		}
 	}
 

--- a/schema/types.go
+++ b/schema/types.go
@@ -168,4 +168,6 @@ func (t AuxiliaryType) String() string {
 const (
 	// AuxiliaryTypeMustSign is used to specify that an action need signature, it is used for `view` action.
 	AuxiliaryTypeMustSign AuxiliaryType = "mustsign"
+	// AuxiliaryTypeOwner is used to specify that an action caller must be the owner of the database.
+	AuxiliaryTypeOwner AuxiliaryType = "owner"
 )


### PR DESCRIPTION
According kwilteam/kwil-db#160, add a new action auxiliary type `owner`.

This pr contains correspond changes with kwilteam/kuneiform-grammar#7