### PR TITLE
fix: remove string value quote from coulmn default

### DIFF
--- a/kfparser/visitor.go
+++ b/kfparser/visitor.go
@@ -234,7 +234,8 @@ func (c *KFVisitor) VisitColumn_constraint(ctx *kfgrammar.Column_constraintConte
 		attr.Type = schema.AttrUnique
 	case ctx.DEFAULT_() != nil:
 		attr.Type = schema.AttrDefault
-		attr.Value = ctx.Literal_value().GetText()
+		// remove the single quote
+		attr.Value = strings.Trim(ctx.Literal_value().GetText(), "'")
 	case ctx.MIN_() != nil:
 		attr.Type = schema.AttrMin
 		attr.Value = ctx.Number_value().GetText()


### PR DESCRIPTION
default value got pass to engine is `"'value'"`, this pr change the value to `"value"`