### PR TITLE
remove block variables @action,@dataset,@caller_address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ go.work
 
 # ide
 .idea
+.vscode
 
 dist/
 

--- a/kfparser/parser_test.go
+++ b/kfparser/parser_test.go
@@ -2,12 +2,14 @@ package kfparser
 
 import (
 	"flag"
+	"strings"
+	"testing"
+
 	"github.com/kwilteam/kuneiform/kfparser/ast"
 	"github.com/kwilteam/kuneiform/schema"
 	"github.com/kwilteam/kuneiform/utils"
+
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 var trace = flag.Bool("trace", false, "run tests with trace enabled")
@@ -558,7 +560,7 @@ func TestParse_valid_syntax(t *testing.T) {
 			action act1($var1, $var2, $var3) private 
 			{ select * from tt1 where tc1 = $var1 or tc2 = $var2 or tc2 = $var3; }
 			action act2() private 
-			{ act1(@caller, @action, @dataset); }`,
+			{ act1(@caller, 'a', 'b'); }`,
 			genOneTableTwoColWithActions(schema.ColInt, schema.ColText,
 				[]schema.Action{
 					{
@@ -573,7 +575,7 @@ func TestParse_valid_syntax(t *testing.T) {
 						Name:       "act2",
 						Mutability: schema.MutabilityUpdate,
 						Statements: []string{
-							`act1(@caller,@action,@dataset);`,
+							`act1(@caller,'a','b');`,
 						},
 					},
 				}...),
@@ -583,7 +585,7 @@ func TestParse_valid_syntax(t *testing.T) {
 			use a_ext{addr: '0x0000', seed: 3} as ext1;
 			table tt1 { tc1 int, tc2 text }
 			action act2() private 
-			{ $v = ext1.call(@caller, @action, @dataset); }`,
+			{ $v = ext1.call(@caller, 'a', 'b'); }`,
 			&schema.Schema{
 				Name:  "td1",
 				Owner: "",
@@ -611,7 +613,7 @@ func TestParse_valid_syntax(t *testing.T) {
 						Name:       "act2",
 						Mutability: schema.MutabilityUpdate,
 						Statements: []string{
-							`$v=ext1.call(@caller,@action,@dataset);`,
+							`$v=ext1.call(@caller,'a','b');`,
 						},
 					},
 				},
@@ -623,7 +625,7 @@ func TestParse_valid_syntax(t *testing.T) {
 			use a_ext{addr: '0x0000', seed: 3} as ext1;
 			table tt1 { tc1 int, tc2 text }
 			action act2($a) private
-			{ $v = ext1.call(2, '3', $a, @dataset, -2, 1 + - 2, (1 * 2) + 3, 1 <= 2, 1 and $a, address(@caller), address(upper(@action))); }`,
+			{ $v = ext1.call(2, '3', $a, @caller, -2, 1 + - 2, (1 * 2) + 3, 1 <= 2, 1 and $a, address(@caller), upper(@caller)); }`,
 			&schema.Schema{
 				Name:  "td1",
 				Owner: "",
@@ -654,7 +656,7 @@ func TestParse_valid_syntax(t *testing.T) {
 							"$a",
 						},
 						Statements: []string{
-							`$v=ext1.call(2,'3',$a,@dataset,-2,1+-2,(1*2)+3,1<=2,1and$a,address(@caller),address(upper(@action)));`,
+							`$v=ext1.call(2,'3',$a,@caller,-2,1+-2,(1*2)+3,1<=2,1and$a,address(@caller),upper(@caller));`,
 						},
 					},
 				},

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -4,17 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kwilteam/kwil-db/parse/action"
-	"github.com/kwilteam/kwil-db/parse/sql"
+	actparser "github.com/kwilteam/kwil-db/parse/action"
+	sqlparser "github.com/kwilteam/kwil-db/parse/sql"
 	"github.com/kwilteam/kwil-db/parse/sql/tree"
 )
 
 var (
 	builtinBlockVars = map[string]bool{
-		"@caller":         true,
-		"@caller_address": true,
-		"@action":         true,
-		"@dataset":        true,
+		"@caller": true,
 	}
 )
 


### PR DESCRIPTION
Following removal of the block variables `@action` and `@dataset` in https://github.com/kwilteam/kwil-db/pull/409, and removal of `@caller_address` in https://github.com/kwilteam/kwil-db/pull/390.

Docs were updated in https://github.com/kwilteam/docs/commit/4a91b0ca04e1d338a78a5fed2d952194eb8dbbba#diff-90b1059866553f6e057cb9705276418742c629d7bb4b346deb13193e3f988efbL120